### PR TITLE
[FEAT] - Validação de Aprovação automática de precatório.

### DIFF
--- a/due/serializer.py
+++ b/due/serializer.py
@@ -48,7 +48,6 @@ class DueDiligenceSerializer(serializers.ModelSerializer):
         dados = {**dados_instance, **data}
 
         status_analise = dados.get('status_analise')
-        documento_aprovado = dados.get('documento_aprovado')
         observacoes = dados.get('observacoes')
         motivo_repactuacao = dados.get('motivo_repactuacao')
 
@@ -66,9 +65,6 @@ class DueDiligenceSerializer(serializers.ModelSerializer):
             if not self.instance:
                 raise serializers.ValidationError('Não é possível criar uma Due Diligence já aprovada.')
             
-            if not documento_aprovado:
-                raise serializers.ValidationError({'documento_aprovado': 'Verifique a aprovação do documento.'})
-            
             pendencias = self.instance.analise_documentos.exclude(
                 status=AnaliseDocumento.StatusDocumento.APROVADO
             ).exists()
@@ -77,5 +73,6 @@ class DueDiligenceSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     'Não é possível aprovar pois existem itens pendentes ou rejeitados.'
                 )
+            data['documento_aprovado'] = True
         
         return data


### PR DESCRIPTION
#6 

Implementação da lógica aprovação automática de liberação de venda do precatório.

- O sistema não pode permitir salvar como **APROVADO** se existir qualquer documento pendente.
- O campo **`documento_aprovado`** é setado para **`True`** automaticamente.
- Se **REPACTUADO**, o status do precatório deve voltar para **`EM_ANALISE`**
- Se **APROVADO**, usamos **`transaction.atomic`** para atualizar o precatório para **DISPONIVEL**

